### PR TITLE
feat: add queue negotiation for book rentals

### DIFF
--- a/src/components/Requests.tsx
+++ b/src/components/Requests.tsx
@@ -3,7 +3,17 @@ import { useSearchParams } from 'react-router-dom';
 import dayjs, { Dayjs } from 'dayjs';
 import Calendar from './Calendar';
 import { useTranslation } from 'react-i18next';
-import { supabase, getOrCreateThread as sbGetOrCreateThread, sendMessage as sbSendMessage, createRent as sbCreateRent } from '../supabase';
+import {
+  supabase,
+  getOrCreateThread as sbGetOrCreateThread,
+  sendMessage as sbSendMessage,
+  createRent as sbCreateRent,
+  createQueueEntry as sbCreateQueueEntry,
+  getQueueEntriesForBookIds,
+  getQueueEntriesByThreadIds,
+  updateQueueEntryStatus,
+  type QueueEntry,
+} from '../supabase';
 import SingleBookReq from './SingleBookReq';
 import FinishedRent from './FinishedRent';
 import { Facehash } from 'facehash';
@@ -62,6 +72,15 @@ const Requests: React.FC<RequestsProps> = ({ onRefreshBooks }) => {
   const [acceptedByBook, setAcceptedByBook] = React.useState<Record<string, { threadId: string; requesterId: string; requesterName: string }>>({});
   const [disabledThreads, setDisabledThreads] = React.useState<Record<string, boolean>>({});
   const [archivedThreads, setArchivedThreads] = React.useState<Record<string, boolean>>({});
+
+  // Queue negotiation state
+  const [queueByThread, setQueueByThread] = React.useState<Record<string, QueueEntry>>({});
+  const [myQueueByThread, setMyQueueByThread] = React.useState<Record<string, QueueEntry>>({});
+  const [proposingFor, setProposingFor] = React.useState<string | null>(null);
+  const [proposeFrom, setProposeFrom] = React.useState<Dayjs | null>(null);
+  const [proposeTo, setProposeTo] = React.useState<Dayjs | null>(null);
+  const [activeRentEndByBook, setActiveRentEndByBook] = React.useState<Record<string, string>>({});
+  const [latestQueueEndByBook, setLatestQueueEndByBook] = React.useState<Record<string, string>>({});
 
   // Borrower flow: compute min date based on active rent
   React.useEffect(() => {
@@ -189,9 +208,27 @@ const Requests: React.FC<RequestsProps> = ({ onRefreshBooks }) => {
         } else {
           setMyArchivedThreads({});
         }
+
+        // load queue proposals directed at me (as borrower)
+        const allThreadIds = Array.from(new Set(mine.map(m => m.threadId)));
+        if (allThreadIds.length > 0) {
+          try {
+            const qEntries = await getQueueEntriesByThreadIds(allThreadIds);
+            const qByThread: Record<string, QueueEntry> = {};
+            qEntries.forEach(qe => {
+              if (!qByThread[qe.threadId]) qByThread[qe.threadId] = qe;
+            });
+            setMyQueueByThread(qByThread);
+          } catch {
+            setMyQueueByThread({});
+          }
+        } else {
+          setMyQueueByThread({});
+        }
       } catch {
         setMyRequests([]);
         setMyArchivedThreads({});
+        setMyQueueByThread({});
       }
     })();
   }, [searchParams]);
@@ -428,12 +465,16 @@ const Requests: React.FC<RequestsProps> = ({ onRefreshBooks }) => {
         if (bookIds.length > 0) {
           const { data: act } = await supabase
             .from('rents')
-            .select('book_id, borrower, finished')
+            .select('book_id, borrower, finished, rent_to')
             .in('book_id', bookIds)
             .eq('finished', false);
           const map: Record<string, boolean> = {};
           const accepted: Record<string, { threadId: string; requesterId: string; requesterName: string }> = {};
-          (act || []).forEach((r: any) => { map[String(r.book_id)] = true; });
+          const rentEndMap: Record<string, string> = {};
+          (act || []).forEach((r: any) => {
+            map[String(r.book_id)] = true;
+            if (r.rent_to) rentEndMap[String(r.book_id)] = String(r.rent_to);
+          });
           // match borrower to request item for threadId
           for (const r of (act || [])) {
             const bId = String(r.book_id);
@@ -448,6 +489,28 @@ const Requests: React.FC<RequestsProps> = ({ onRefreshBooks }) => {
           }
           setActiveRentByBook(map);
           setAcceptedByBook(accepted);
+          setActiveRentEndByBook(rentEndMap);
+
+          // load queue entries for these books
+          try {
+            const qEntries = await getQueueEntriesForBookIds(bookIds);
+            const qByThread: Record<string, QueueEntry> = {};
+            const latestQEnd: Record<string, string> = {};
+            qEntries.forEach(qe => {
+              // keep the most recent entry per thread (they're ordered by created_at desc in DB)
+              if (!qByThread[qe.threadId]) qByThread[qe.threadId] = qe;
+              // track latest accepted queue end per book for min-date calculation
+              if (qe.status === 'accepted') {
+                const cur = latestQEnd[qe.bookId];
+                if (!cur || qe.proposedTo > cur) latestQEnd[qe.bookId] = qe.proposedTo;
+              }
+            });
+            setQueueByThread(qByThread);
+            setLatestQueueEndByBook(latestQEnd);
+          } catch {
+            setQueueByThread({});
+            setLatestQueueEndByBook({});
+          }
           // restore disabled threads — only keep disabled if the book is still actively rented
           try {
             const raw = localStorage.getItem('req_disabled_threads');
@@ -494,6 +557,119 @@ const Requests: React.FC<RequestsProps> = ({ onRefreshBooks }) => {
     })();
   }, [searchParams]);
 
+  // ── Queue negotiation handlers ──────────────────────────────────────────
+
+  async function openProposal(it: RequestItem) {
+    // activeRentEndByBook may be empty if owner just agreed in this session
+    // — fetch from DB as fallback
+    let rentEnd = activeRentEndByBook[it.bookId];
+    if (!rentEnd) {
+      try {
+        const { data } = await supabase
+          .from('rents')
+          .select('rent_to')
+          .eq('book_id', it.bookId)
+          .eq('finished', false)
+          .maybeSingle();
+        if (data?.rent_to) {
+          rentEnd = String(data.rent_to);
+          setActiveRentEndByBook(prev => ({ ...prev, [it.bookId]: rentEnd! }));
+        }
+      } catch {}
+    }
+    const queueEnd = latestQueueEndByBook[it.bookId];
+    const later = rentEnd && queueEnd
+      ? (dayjs(rentEnd).isAfter(dayjs(queueEnd)) ? rentEnd : queueEnd)
+      : (rentEnd || queueEnd);
+    // +1 dzień margines po zakończeniu aktualnego wypożyczenia / ostatniej kolejki
+    const minDate = later ? dayjs(later).add(1, 'day') : dayjs();
+    setProposeFrom(minDate);
+    setProposeTo(null);
+    setProposingFor(it.threadId);
+  }
+
+  async function handleConfirmProposal(it: RequestItem) {
+    if (!proposeFrom || !proposeTo) return;
+    try {
+      setSubmitting(true);
+      setError(null);
+      const { data: auth } = await supabase.auth.getUser();
+      const currentUserId = auth.user?.id;
+      if (!currentUserId) { setError('Not authenticated'); return; }
+      const fromStr = proposeFrom.format('YYYY-MM-DD');
+      const toStr = proposeTo.format('YYYY-MM-DD');
+      const qe = await sbCreateQueueEntry({
+        bookId: it.bookId,
+        bookOwner: currentUserId,
+        borrower: it.requesterId,
+        threadId: it.threadId,
+        proposedFrom: fromStr,
+        proposedTo: toStr,
+      });
+      await sbSendMessage({
+        senderId: currentUserId,
+        recipientId: it.requesterId,
+        body: `!system: Owner proposed queue dates from ${fromStr} to ${toStr}.`,
+        threadId: it.threadId,
+      });
+      setQueueByThread(prev => ({ ...prev, [it.threadId]: qe }));
+      setProposingFor(null);
+      setProposeFrom(null);
+      setProposeTo(null);
+      await refreshOwnerCalendar();
+    } catch (e: any) {
+      setError(e?.message ?? 'Failed to propose date');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleAcceptProposal(it: RequestItem, qe: QueueEntry) {
+    try {
+      setSubmitting(true);
+      setError(null);
+      const { data: auth } = await supabase.auth.getUser();
+      const currentUserId = auth.user?.id;
+      if (!currentUserId) { setError('Not authenticated'); return; }
+      await updateQueueEntryStatus(qe.id, 'accepted');
+      await sbSendMessage({
+        senderId: currentUserId,
+        recipientId: qe.bookOwner,
+        body: '!system: Borrower accepted queued dates.',
+        threadId: it.threadId,
+      });
+      setMyQueueByThread(prev => ({ ...prev, [it.threadId]: { ...qe, status: 'accepted' } }));
+    } catch (e: any) {
+      setError(e?.message ?? 'Failed to accept proposal');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleDeclineProposal(it: RequestItem, qe: QueueEntry) {
+    try {
+      setSubmitting(true);
+      setError(null);
+      const { data: auth } = await supabase.auth.getUser();
+      const currentUserId = auth.user?.id;
+      if (!currentUserId) { setError('Not authenticated'); return; }
+      await updateQueueEntryStatus(qe.id, 'declined');
+      await sbSendMessage({
+        senderId: currentUserId,
+        recipientId: qe.bookOwner,
+        body: '!system: Borrower declined queued dates.',
+        threadId: it.threadId,
+      });
+      // Nie archiwizujemy wątku — owner może zaproponować nowy termin,
+      // a borrower musi być w stanie go zobaczyć
+      setMyQueueByThread(prev => ({ ...prev, [it.threadId]: { ...qe, status: 'declined' } }));
+    } catch (e: any) {
+      setError(e?.message ?? 'Failed to decline proposal');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
   // Build/refresh owner calendar (active rents per owned book)
   const refreshOwnerCalendar = React.useCallback(async () => {
     try {
@@ -520,9 +696,46 @@ const Requests: React.FC<RequestsProps> = ({ onRefreshBooks }) => {
         const fallback = (u.email || '').split('@')[0] || '';
         return [String(u.id), full || fallback];
       }));
-      const resources = bookIds.map(id => ({ id, name: bookIdToTitle.get(id) || id }));
+      // Also fetch queue entries for calendar display
+      const { data: queueRows } = await supabase
+        .from('rent_queue')
+        .select('book_id, borrower, proposed_from, proposed_to, status')
+        .eq('book_owner', currentUserId)
+        .in('status', ['proposed', 'accepted']);
+      const queueBorrowerIds = Array.from(new Set((queueRows || []).map((r: any) => String(r.borrower))));
+      let queueUsersRows: any[] = [];
+      if (queueBorrowerIds.length > 0) {
+        const { data: quRows } = await supabase
+          .from('users')
+          .select('id, first_name, last_name, email')
+          .in('id', queueBorrowerIds);
+        queueUsersRows = quRows || [];
+      }
+      const queueUserIdToName = new Map<string, string>([
+        ...Array.from(userIdToName.entries()),
+        ...queueUsersRows.map((u: any) => {
+          const first = (u.first_name || '').trim();
+          const last = (u.last_name || '').trim();
+          const full = [first, last].filter(Boolean).join(' ');
+          return [String(u.id), full || (u.email || '').split('@')[0] || ''] as [string, string];
+        }),
+      ]);
+
+      // Build all calendar resources (union of rent books + queue books)
+      const allBookIds = Array.from(new Set([
+        ...bookIds,
+        ...(queueRows || []).map((r: any) => String(r.book_id)),
+      ]));
+      // Resolve any extra book titles for queue-only books
+      const missingBookIds = allBookIds.filter(id => !bookIdToTitle.has(id));
+      if (missingBookIds.length > 0) {
+        const { data: extraBooks } = await supabase.from('books').select('id, title').in('id', missingBookIds);
+        (extraBooks || []).forEach((b: any) => bookIdToTitle.set(String(b.id), String(b.title ?? '')));
+      }
+
+      const resources = allBookIds.map(id => ({ id, name: bookIdToTitle.get(id) || id }));
       const now = dayjs();
-      const events = rents.map((r: any, idx: number) => {
+      const activeEvents = rents.map((r: any, idx: number) => {
         const startIso = r.rent_from ? dayjs(r.rent_from).startOf('day').toISOString() : dayjs().startOf('day').toISOString();
         // DayPilot interpretuje "end" ekskluzywnie – dodaj 1 dzień, by okres był inkluzywny
         const endIso = r.rent_to ? dayjs(r.rent_to).add(1, 'day').startOf('day').toISOString() : dayjs().add(1, 'day').startOf('day').toISOString();
@@ -533,8 +746,15 @@ const Requests: React.FC<RequestsProps> = ({ onRefreshBooks }) => {
         const cssClass = isActive ? 'dp-event--active' : 'dp-event--upcoming';
         return { id: `${String(r.book_id)}_${idx}`, start: startIso, end: endIso, resource: String(r.book_id), text: borrower, cssClass } as any;
       });
+      const queueEvents = (queueRows || []).map((r: any, idx: number) => {
+        const startIso = dayjs(r.proposed_from).startOf('day').toISOString();
+        const endIso = dayjs(r.proposed_to).add(1, 'day').startOf('day').toISOString();
+        const borrower = queueUserIdToName.get(String(r.borrower)) || 'User';
+        const cssClass = r.status === 'accepted' ? 'dp-event--queued-accepted' : 'dp-event--queued-proposed';
+        return { id: `q_${String(r.book_id)}_${idx}`, start: startIso, end: endIso, resource: String(r.book_id), text: borrower, cssClass } as any;
+      });
       setCalResources(resources);
-      setCalEvents(events);
+      setCalEvents([...activeEvents, ...queueEvents]);
     } catch {
       setCalResources([]);
       setCalEvents([]);
@@ -794,21 +1014,125 @@ const Requests: React.FC<RequestsProps> = ({ onRefreshBooks }) => {
                     <div className="request-chip request-chip--archived">
                       {t('requests.archived') || 'Archived request'}
                     </div>
+                  ) : activeRentByBook[it.bookId] ? (
+                    (() => {
+                      const qe = queueByThread[it.threadId];
+                      // Date picker open for this thread
+                      if (proposingFor === it.threadId) {
+                        const rentEnd = activeRentEndByBook[it.bookId];
+                        const queueEnd = latestQueueEndByBook[it.bookId];
+                        const later = rentEnd && queueEnd
+                          ? (dayjs(rentEnd).isAfter(dayjs(queueEnd)) ? rentEnd : queueEnd)
+                          : (rentEnd || queueEnd);
+                        const minPropose = later ? dayjs(later).add(1, 'day') : dayjs();
+                        return (
+                          <div className="propose-date-panel">
+                            {later && (
+                              <p className="propose-date-hint">
+                                {t('requests.proposeDateHint', { date: minPropose.format('DD.MM.YYYY') })}
+                              </p>
+                            )}
+                            <div className="request-compose__dates">
+                              <div className="request-date">
+                                <Calendar
+                                  label={t('messages.rentFrom') || 'Od'}
+                                  value={proposeFrom}
+                                  onChange={(v) => setProposeFrom(v)}
+                                  required
+                                  error={!proposeFrom}
+                                  minDate={minPropose}
+                                />
+                              </div>
+                              <div className="request-date">
+                                <Calendar
+                                  label={t('messages.rentTo') || 'Do'}
+                                  value={proposeTo}
+                                  onChange={(v) => setProposeTo(v)}
+                                  required
+                                  error={!proposeTo}
+                                  minDate={proposeFrom ?? minPropose}
+                                />
+                              </div>
+                            </div>
+                            <div className="request-actions">
+                              <button
+                                className="btn btn--ghost"
+                                disabled={submitting}
+                                onClick={() => { setProposingFor(null); setProposeFrom(null); setProposeTo(null); }}
+                              >
+                                {t('requests.cancelProposal') || 'Anuluj'}
+                              </button>
+                              <button
+                                className="btn"
+                                disabled={submitting || !proposeFrom || !proposeTo}
+                                onClick={() => handleConfirmProposal(it)}
+                              >
+                                {t('requests.confirmProposal') || 'Potwierdź termin'}
+                              </button>
+                            </div>
+                          </div>
+                        );
+                      }
+                      // Proposal pending — waiting for borrower
+                      if (qe?.status === 'proposed') {
+                        return (
+                          <div className="request-chip request-chip--info">
+                            {t('requests.pendingProposal')}: {qe.proposedFrom} – {qe.proposedTo}
+                          </div>
+                        );
+                      }
+                      // Proposal accepted by borrower
+                      if (qe?.status === 'accepted') {
+                        return (
+                          <div className="request-chip request-chip--queued">
+                            {t('requests.queuedBorrower')}: {qe.proposedFrom} – {qe.proposedTo}
+                          </div>
+                        );
+                      }
+                      // Proposal declined by borrower — allow re-proposal or disagree
+                      if (qe?.status === 'declined') {
+                        return (
+                          <>
+                            <div className="request-chip request-chip--warning">
+                              {t('requests.borrowerDeclined')}
+                            </div>
+                            <div className="request-actions">
+                              <button
+                                className="btn btn--ghost-blue"
+                                disabled={submitting}
+                                onClick={() => openProposal(it)}
+                              >
+                                {t('requests.proposeNewDate')}
+                              </button>
+                              <button className="btn btn--ghost" disabled={submitting} onClick={() => handleDisagree(it)}>
+                                {t('messages.disagree')}
+                              </button>
+                            </div>
+                          </>
+                        );
+                      }
+                      // No proposal yet — show main CTA
+                      return (
+                        <div className="request-actions">
+                          <button
+                            className="btn btn--ghost-blue"
+                            disabled={submitting}
+                            onClick={() => openProposal(it)}
+                          >
+                            {t('requests.proposeDate')}
+                          </button>
+                          <button className="btn btn--ghost" disabled={submitting} onClick={() => handleDisagree(it)}>
+                            {t('messages.disagree')}
+                          </button>
+                        </div>
+                      );
+                    })()
                   ) : (
                     <div className="request-actions">
                       <button
                         className="btn"
-                        disabled={submitting || !!activeRentByBook[it.bookId] || !!disabledThreads[it.threadId]}
-                        title={
-                          activeRentByBook[it.bookId]
-                            ? (() => {
-                                const borrowerName = acceptedByBook[it.bookId]?.requesterName;
-                                return borrowerName
-                                  ? (t('requests.waitingForReturn', { name: borrowerName }) || `Dostępne gdy ${borrowerName} odda książkę`)
-                                  : (t('requests.bookAlreadyRented') || 'Book already rented');
-                              })()
-                            : (disabledThreads[it.threadId] ? (t('requests.requestCompleted') || 'This request already completed') : undefined)
-                        }
+                        disabled={submitting || !!disabledThreads[it.threadId]}
+                        title={disabledThreads[it.threadId] ? (t('requests.requestCompleted') || 'This request already completed') : undefined}
                         onClick={() => handleAgree(it)}
                       >
                         {t('messages.agree')}
@@ -856,6 +1180,50 @@ const Requests: React.FC<RequestsProps> = ({ onRefreshBooks }) => {
                       isMine
                     />
                   </div>
+                  {(() => {
+                    const qe = myQueueByThread[it.threadId];
+                    if (!qe) return null;
+                    if (qe.status === 'accepted') {
+                      return (
+                        <div className="request-chip request-chip--queued">
+                          {t('requests.borrowerAccepted')}: {qe.proposedFrom} – {qe.proposedTo}
+                        </div>
+                      );
+                    }
+                    if (qe.status === 'declined') {
+                      // Wątek nadal aktywny — owner może zaproponować nowe daty
+                      return (
+                        <div className="request-chip request-chip--warning">
+                          {t('requests.borrowerDeclined')}
+                        </div>
+                      );
+                    }
+                    // status === 'proposed' — pokaż przyciski akceptacji
+                    return (
+                      <div className="proposed-date-banner">
+                        <div className="proposed-date-info">
+                          <strong>{t('requests.ownerProposedDate')}:</strong>{' '}
+                          {qe.proposedFrom} – {qe.proposedTo}
+                        </div>
+                        <div className="request-actions">
+                          <button
+                            className="btn"
+                            disabled={submitting}
+                            onClick={() => handleAcceptProposal(it, qe)}
+                          >
+                            {t('requests.acceptDate')}
+                          </button>
+                          <button
+                            className="btn btn--ghost"
+                            disabled={submitting}
+                            onClick={() => handleDeclineProposal(it, qe)}
+                          >
+                            {t('requests.declineDate')}
+                          </button>
+                        </div>
+                      </div>
+                    );
+                  })()}
                   <div className="request-actions" />
                 </div>
               ))}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -159,7 +159,19 @@
     "mine": "My requests",
     "archivedTab": "Archived",
     "pending": "Pending",
-    "owner": "Owner"
+    "owner": "Owner",
+    "proposeDate": "Propose alternative date",
+    "proposeNewDate": "Propose new date",
+    "confirmProposal": "Confirm date",
+    "cancelProposal": "Cancel",
+    "proposeDateHint": "Book available from: {{date}}",
+    "queuedBorrower": "Queued borrower",
+    "pendingProposal": "Waiting for acceptance",
+    "acceptDate": "Accept date",
+    "declineDate": "Decline date",
+    "ownerProposedDate": "Owner proposes a date",
+    "borrowerDeclined": "Borrower declined the proposed date",
+    "borrowerAccepted": "Borrower accepted the date"
   },
   "systemMemo": {
     "systemLabel": "System"

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -159,7 +159,19 @@
     "mine": "Moje prośby",
     "archivedTab": "Zarchiwizowane",
     "pending": "Oczekuje",
-    "owner": "Właściciel"
+    "owner": "Właściciel",
+    "proposeDate": "Zaproponuj inny termin",
+    "proposeNewDate": "Zaproponuj nowy termin",
+    "confirmProposal": "Potwierdź termin",
+    "cancelProposal": "Anuluj",
+    "proposeDateHint": "Książka wolna od: {{date}}",
+    "queuedBorrower": "Zakolejkowany wypożyczający",
+    "pendingProposal": "Oczekuje na akceptację",
+    "acceptDate": "Akceptuję termin",
+    "declineDate": "Odrzucam termin",
+    "ownerProposedDate": "Właściciel proponuje termin",
+    "borrowerDeclined": "Wypożyczający odrzucił proponowany termin",
+    "borrowerAccepted": "Wypożyczający zaakceptował termin"
   },
   "systemMemo": {
     "systemLabel": "System"

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1670,9 +1670,70 @@ body.modal-open { overflow: hidden; }
   margin-top: var(--sp-2);
 }
 
+/* Request chips */
+.request-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  margin-top: var(--sp-3);
+}
+.request-chip--success { background: #d1fae5; color: #065f46; }
+.request-chip--archived { background: #f1f5f9; color: #64748b; }
+.request-chip--info { background: #dbeafe; color: #1e40af; }
+.request-chip--queued { background: #ede9fe; color: #4c1d95; }
+.request-chip--warning { background: #fef3c7; color: #92400e; }
+
+/* Propose-date inline panel */
+.propose-date-panel {
+  margin-top: var(--sp-3);
+  padding: var(--sp-3);
+  background: #f8fafc;
+  border: 1px solid var(--c-border);
+  border-radius: var(--r-lg);
+}
+.propose-date-hint {
+  font-size: 0.78rem;
+  color: #64748b;
+  margin-bottom: var(--sp-2);
+}
+
+/* Borrower proposed-date banner */
+.proposed-date-banner {
+  margin-top: var(--sp-3);
+  padding: var(--sp-3);
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  border-radius: var(--r-lg);
+}
+.proposed-date-info {
+  font-size: 0.85rem;
+  color: #1e40af;
+  margin-bottom: var(--sp-2);
+}
+
+/* Ghost blue button */
+.btn--ghost-blue {
+  background: transparent;
+  border: 1.5px solid #3b82f6;
+  color: #2563eb;
+  border-radius: var(--r-lg);
+  padding: var(--sp-2) var(--sp-3);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.btn--ghost-blue:hover { background: #eff6ff; }
+.btn--ghost-blue:disabled { opacity: 0.4; cursor: not-allowed; }
+
 /* DayPilot event colors */
 .dp-event--active  { background: rgba(45,186,104,.15) !important; border-color: #34d399 !important; }
 .dp-event--upcoming { background: var(--c-bg) !important; border-color: var(--c-border) !important; }
+.dp-event--queued-accepted { background: rgba(99,102,241,.18) !important; border-color: #6366f1 !important; border-style: dashed !important; }
+.dp-event--queued-proposed { background: rgba(147,197,253,.35) !important; border-color: #3b82f6 !important; border-style: dotted !important; color: #1e3a5f !important; }
 
 /* Calendar list (mobile) */
 .calendar-list { padding: var(--sp-2); }
@@ -1703,6 +1764,16 @@ body.modal-open { overflow: hidden; }
 .calendar-list__item.dp-event--active {
   border-color: var(--c-green-tint-border);
   background: var(--c-green-tint);
+}
+.calendar-list__item.dp-event--queued-accepted {
+  border-color: #6366f1;
+  background: rgba(99,102,241,.08);
+  border-style: dashed;
+}
+.calendar-list__item.dp-event--queued-proposed {
+  border-color: #3b82f6;
+  background: rgba(147,197,253,.2);
+  border-style: dotted;
 }
 
 .calendar-list__title {

--- a/src/supabase.ts
+++ b/src/supabase.ts
@@ -260,6 +260,92 @@ export async function getOwnerName(ownerId: string): Promise<string> {
   return full;
 }
 
+// ── rent_queue helpers ──────────────────────────────────────────────────────
+
+export type QueueEntry = {
+  id: string;
+  bookId: string;
+  bookOwner: string;
+  borrower: string;
+  threadId: string;
+  proposedFrom: string; // YYYY-MM-DD
+  proposedTo: string;   // YYYY-MM-DD
+  status: 'proposed' | 'accepted' | 'declined';
+  createdAt: string;
+};
+
+export async function createQueueEntry(params: {
+  bookId: string;
+  bookOwner: string;
+  borrower: string;
+  threadId: string;
+  proposedFrom: string;
+  proposedTo: string;
+}): Promise<QueueEntry> {
+  const { data, error } = await supabase
+    .from('rent_queue')
+    .insert([{
+      book_id: params.bookId,
+      book_owner: params.bookOwner,
+      borrower: params.borrower,
+      thread_id: params.threadId,
+      proposed_from: params.proposedFrom,
+      proposed_to: params.proposedTo,
+      status: 'proposed',
+    }])
+    .select()
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return mapQueueRow(data);
+}
+
+export async function getQueueEntriesForBookIds(bookIds: string[]): Promise<QueueEntry[]> {
+  if (!bookIds.length) return [];
+  const { data, error } = await supabase
+    .from('rent_queue')
+    .select('*')
+    .in('book_id', bookIds)
+    .order('created_at', { ascending: false });
+  if (error) throw new Error(error.message);
+  return (data || []).map(mapQueueRow);
+}
+
+export async function getQueueEntriesByThreadIds(threadIds: string[]): Promise<QueueEntry[]> {
+  if (!threadIds.length) return [];
+  const { data, error } = await supabase
+    .from('rent_queue')
+    .select('*')
+    .in('thread_id', threadIds)
+    .order('created_at', { ascending: false });
+  if (error) throw new Error(error.message);
+  return (data || []).map(mapQueueRow);
+}
+
+export async function updateQueueEntryStatus(
+  queueId: string,
+  status: 'accepted' | 'declined'
+): Promise<void> {
+  const { error } = await supabase
+    .from('rent_queue')
+    .update({ status, updated_at: new Date().toISOString() })
+    .eq('id', queueId);
+  if (error) throw new Error(error.message);
+}
+
+function mapQueueRow(r: any): QueueEntry {
+  return {
+    id: String(r.id),
+    bookId: String(r.book_id),
+    bookOwner: String(r.book_owner),
+    borrower: String(r.borrower),
+    threadId: String(r.thread_id),
+    proposedFrom: String(r.proposed_from),
+    proposedTo: String(r.proposed_to),
+    status: r.status as QueueEntry['status'],
+    createdAt: String(r.created_at),
+  };
+}
+
 export async function submitUserRating(params: {
   rateeId: string;
   raterId: string;

--- a/supabase/migrations/20260417120000_create_rent_queue.sql
+++ b/supabase/migrations/20260417120000_create_rent_queue.sql
@@ -1,0 +1,38 @@
+-- Tabela rent_queue: przechowuje kolejkowane propozycje dat wypożyczenia
+-- Kiedy książka jest już wypożyczona, owner może zaproponować alternatywne daty
+-- kolejnemu zainteresowanemu użytkownikowi.
+
+create table if not exists public.rent_queue (
+  id uuid primary key default gen_random_uuid(),
+  book_id uuid not null references public.books(id) on delete cascade,
+  book_owner uuid not null references public.users(id) on delete restrict,
+  borrower uuid not null references public.users(id) on delete restrict,
+  thread_id uuid not null references public.threads(id) on delete cascade,
+  proposed_from date not null,
+  proposed_to date not null,
+  status text not null default 'proposed'
+    check (status in ('proposed', 'accepted', 'declined')),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- jedno aktywne zaproszenie na wątek
+create unique index rent_queue_one_active_per_thread
+  on public.rent_queue (thread_id)
+  where (status = 'proposed');
+
+create index idx_rent_queue_book on public.rent_queue (book_id);
+create index idx_rent_queue_owner on public.rent_queue (book_owner, status);
+create index idx_rent_queue_borrower on public.rent_queue (borrower, status);
+
+alter table public.rent_queue enable row level security;
+
+create policy rq_select on public.rent_queue for select
+  using (auth.uid() = book_owner or auth.uid() = borrower);
+
+create policy rq_insert on public.rent_queue for insert
+  with check (auth.uid() = book_owner);
+
+create policy rq_update on public.rent_queue for update
+  using (auth.uid() = book_owner or auth.uid() = borrower)
+  with check (true);


### PR DESCRIPTION
When a book is already rented, owner can propose alternative dates to queued borrowers instead of just disabling the Agree button. Borrowers can accept or decline proposals from their Requests view. Calendar now shows queued (proposed/accepted) periods with distinct colors.